### PR TITLE
Update Program.cs to fix broken UNC path

### DIFF
--- a/SharpPrintNightmare/SharpPrintNightmare/Program.cs
+++ b/SharpPrintNightmare/SharpPrintNightmare/Program.cs
@@ -70,7 +70,10 @@ namespace SharpPrintNightmare
             dllpath = args[0];
             if (dllpath.Contains("\\\\"))
             {
-                dllpath = dllpath.Replace("\\\\", "\\??\\UNC\\");
+                // only replace the first occurence of \\\\
+                string pattern = "\\\\";
+                int position = dllpath.IndexOf("\\\\");
+                dllpath = dllpath.Remove(position, pattern.Length).Insert(position, "\\??\\UNC\\");
             }
 
             if (args.Length > 2)


### PR DESCRIPTION
Changed to code to only replace the first occurence of \\\\ in the dllpath.

The current code was broken when the UNC path contains multiple folders ex: \\server\folder\my.dll